### PR TITLE
Enhance Firestore rules for app settings access and implement modal f…

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -104,11 +104,12 @@ service cloud.firestore {
       allow read: if true; // Temporary for testing
     }
 
-    // App Settings collection - Only admins can read/write
+    // App Settings collection
+    // Public read so unauthenticated pages (e.g., login) can load branding
+    // Write remains restricted to admins only
     match /app_settings/{settingId} {
-      allow read, write: if isAdmin();
-      // Allow read for authenticated users to display app info
-      allow read: if isAuthenticated();
+      allow read: if true;
+      allow write: if isAdmin();
     }
   }
 }

--- a/src/pages/Laporan.js
+++ b/src/pages/Laporan.js
@@ -29,6 +29,7 @@ const Laporan = () => {
   const [filterYear, setFilterYear] = useState('2024');
   const [showAuditSelection, setShowAuditSelection] = useState(false);
   const [availableAudits, setAvailableAudits] = useState([]);
+  const [showTemplateModal, setShowTemplateModal] = useState(false);
 
 
   useEffect(() => {
@@ -959,7 +960,7 @@ const Laporan = () => {
         </div>
         <button 
           className="generate-report-btn"
-          onClick={() => handleGenerateReport({ title: 'Laporan Umum' })}
+          onClick={() => setShowTemplateModal(true)}
         >
           <span>📄</span>
           Generate Laporan
@@ -1271,8 +1272,51 @@ const Laporan = () => {
            </div>
          </div>
        )}
-     </div>
-   );
- };
+      {showTemplateModal && (
+        <div className="modal-overlay">
+          <div className="modal-content audit-selection-modal">
+            <div className="modal-header">
+              <h3>Pilih Jenis Laporan</h3>
+              <button 
+                className="modal-close"
+                onClick={() => setShowTemplateModal(false)}
+              >
+                ×
+              </button>
+            </div>
+            <div className="modal-body">
+              <div className="templates-grid">
+                {reportTemplates.map((template) => (
+                  <div
+                    key={template.id}
+                    className="template-card"
+                    onClick={async () => {
+                      setShowTemplateModal(false);
+                      await handleGenerateReport(template);
+                    }}
+                  >
+                    <div className="template-icon">{template.icon}</div>
+                    <div className="template-content">
+                      <h4>{template.title}</h4>
+                      <p>{template.subtitle}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="modal-footer">
+              <button 
+                className="btn-secondary"
+                onClick={() => setShowTemplateModal(false)}
+              >
+                Tutup
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
 
 export default Laporan;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1181,12 +1181,12 @@ body {
   font-size: 14px;
 }
 
+/* Remove automatic required marker on labels */
 .form-group label::after {
-  content: " *";
-  color: #ef4444;
-  font-weight: bold;
+  content: "";
 }
 
+/* Keep empty for non-required fields as well (no marker at all) */
 .form-group label:has(input:not([required]))::after,
 .form-group label:has(select:not([required]))::after,
 .form-group label:has(textarea:not([required]))::after {


### PR DESCRIPTION
…or report template selection in Laporan page

- Updated Firestore rules to allow public read access to app settings, enabling unauthenticated users to load branding while restricting write access to admins.
- Added a modal in the Laporan page for selecting report templates, improving user experience in report generation.
- Updated global CSS to remove automatic required markers on labels for non-required fields, enhancing form usability.